### PR TITLE
change: 体育科目のURLやタイトルの変更

### DIFF
--- a/src/content/subjectsData.ts
+++ b/src/content/subjectsData.ts
@@ -74,7 +74,7 @@ export const subjectMap = new Map<
                     },
                 ]
             >(([subject_number, subject]) => [
-                `${subject_category}-${subject.name}`,
+                `${subject.name}-${subject_category}`,
                 {
                     type: "体育",
                     name: subject.name,

--- a/src/pages/details/[id].astro
+++ b/src/pages/details/[id].astro
@@ -2,13 +2,10 @@
 import Layout from "../../layouts/Layout.astro";
 import Header from "../../components/Header.astro";
 import SideMenu from "../../components/SideMenu.astro";
-// import { summaryData } from "../../content/summary_merged";
-import { subjectMap } from '../../content/subjectsData';
+import { subjectMap } from "../../content/subjectsData";
 import { kdbData } from "../../content/kdb-schema";
 import LabelPercent from "../../components/LabelPercent.astro";
 import pageStyles from "./page.module.scss";
-
-
 
 export function getStaticPaths() {
     return [...subjectMap.keys()].map((subject) => ({
@@ -174,8 +171,14 @@ const params =
     <Header isMain={false} />
     <main class={pageStyles.main}>
         <div class={pageStyles.body}>
-            <h1 class={pageStyles.title}>{subjectName}</h1>
-
+            <h1 class={pageStyles.title}>{subject.name}</h1>
+            {
+                subject.type === "体育" && (
+                    <span class={pageStyles.category}>
+                        {subject.subject_category}
+                    </span>
+                )
+            }
             {
                 params.class_format && (
                     <>

--- a/src/pages/details/page.module.scss
+++ b/src/pages/details/page.module.scss
@@ -16,6 +16,17 @@
             font-weight: 600;
             margin: 0 0 20px;
         }
+        .category {
+            display: inline-block;
+            font-size: 14px;
+            font-weight: bold;
+            padding: 6px 18px;
+            border-radius: 20px;
+            border: 1px solid #00C1D4;
+            background-color: #ffffff;
+            color: #101010;
+            margin-left: 10px;
+        }
         .tagWrap {
             display: flex;
             gap: 30px;


### PR DESCRIPTION
https://change-taiiku-detail-title.bridge-2024.pages.dev/details/基礎体育卓球(春)-社会,国際,教育,心理,障害,資源,情報,知識,総学5,6組（1年次）

URLとページタイトルの科目名とカテゴリーの順番を入れ替え、ページ内の科目名を科目名のみにし、カテゴリーを別に書いた