### PR TITLE
fix: Aboutページのタイトルを実態に即したものに修正

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -9,7 +9,7 @@ const currentUrl = Astro.url;
 
 ---
 
-<Layout title="brige">
+<Layout title="BRIDGEとは">
     <Header isMain={false}>
         <SearchBox defaultInput={""} styleAttr="margin: 40px 0 20px;" />
     </Header>


### PR DESCRIPTION
Aboutページのタイトルが仮に「brige」となっていたものを実態に即した「BRIDGEとは」に修正した